### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/damiankisielewski0472/d25ed9c7-5116-4701-aed7-74d489c86233/be0a1910-e4cd-407d-accd-9bebc5983cc0/_apis/work/boardbadge/d4ee7055-13a3-4b84-87f1-c00bfdf2ff2b)](https://dev.azure.com/damiankisielewski0472/d25ed9c7-5116-4701-aed7-74d489c86233/_boards/board/t/be0a1910-e4cd-407d-accd-9bebc5983cc0/Microsoft.RequirementCategory)
 ### `npm install
 ### `npm start`
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/damiankisielewski0472/d25ed9c7-5116-4701-aed7-74d489c86233/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.